### PR TITLE
Fix some API views not displaying

### DIFF
--- a/cyb_oko/settings.py
+++ b/cyb_oko/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = (
     'z',
     'members',
     'intern',
+    'django_filters',
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
django_filters wasn't added to INSTALLED_APPS

See carltongibson/django-filter#562 for more details